### PR TITLE
Updates based on Next best practices

### DIFF
--- a/next/babel.config.js
+++ b/next/babel.config.js
@@ -2,7 +2,7 @@
 module.exports = {
 
   presets: [
-    '@babel/preset-react' // necessary for all .jsx files
+    'next/babel'
   ],
 
   // fullcalendar attempts to import its own CSS files, but next.js does not allow this.

--- a/next/package.json
+++ b/next/package.json
@@ -16,7 +16,7 @@
     "@fullcalendar/interaction": "^5.0.0",
     "@fullcalendar/timegrid": "^5.0.0",
     "babel-plugin-transform-require-ignore": "^0.1.1",
-    "next": "^9.4.4",
+    "next": "^9.5.5",
     "next-transpile-modules": "^4.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/next/pages/_app.jsx
+++ b/next/pages/_app.jsx
@@ -1,8 +1,3 @@
-import React from 'react'
-
-import '@fullcalendar/common/main.css'
-import '@fullcalendar/daygrid/main.css'
-import '@fullcalendar/timegrid/main.css'
 import '../global-styles.css'
 
 export default function App({ Component, pageProps }) {

--- a/next/pages/index.jsx
+++ b/next/pages/index.jsx
@@ -1,16 +1,21 @@
-import React from 'react'
 import FullCalendar from '@fullcalendar/react'
 import interactionPlugin from '@fullcalendar/interaction'
 import timeGridPlugin from '@fullcalendar/timegrid'
 
-export default () => (
-  <FullCalendar
-    plugins={[interactionPlugin, timeGridPlugin]}
-    initialView='timeGridWeek'
-    nowIndicator={true}
-    editable={true}
-    initialEvents={[
-      { title: 'nice event', start: new Date() }
-    ]}
-  />
-)
+import '@fullcalendar/common/main.css'
+import '@fullcalendar/daygrid/main.css'
+import '@fullcalendar/timegrid/main.css'
+
+export default function IndexPage() {
+  return (
+    <FullCalendar
+      plugins={[interactionPlugin, timeGridPlugin]}
+      initialView='timeGridWeek'
+      nowIndicator={true}
+      editable={true}
+      initialEvents={[
+        { title: 'nice event', start: new Date() }
+      ]}
+    />
+  )
+}


### PR DESCRIPTION
Thanks for a great project and example 🎉  I updated it based on a few of Next's best practices:

* Use [`next/babel`](https://nextjs.org/docs/advanced-features/customizing-babel-config) as the Babel preset
* No need to import React! Next imports it by default in the most optimized way
* Fast refresh only works with named components/pages, therefore I named the page component
* [Next now supports importing CSS directly](https://nextjs.org/docs/basic-features/built-in-css-support#import-styles-from-node_modules) in the page/component it is used, so it can be moved to the `index` component