### PR TITLE
fix example with mobx 6

### DIFF
--- a/react-mobx-typescript/src/event-store.ts
+++ b/react-mobx-typescript/src/event-store.ts
@@ -1,8 +1,13 @@
 import { createContext } from "react";
-import { observable, action } from "mobx";
+import { observable, action, makeObservable } from "mobx";
 import { EventInput, DateSelectArg, EventChangeArg } from "@fullcalendar/react";
 
 export class EventStore {
+  constructor() {
+    // see https://mobx.js.org/enabling-decorators.html
+    makeObservable(this);
+  }
+
   @observable
   weekendsVisible = true;
 

--- a/react-mobx-typescript/tsconfig.json
+++ b/react-mobx-typescript/tsconfig.json
@@ -11,7 +11,8 @@
     "sourceMap": true,
     "rootDir": "src",
     "outDir": "tsc",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "useDefineForClassFields": true
   },
   "include": ["src/main.tsx"]
 }


### PR DESCRIPTION
MobX 6 can leverage decorators but they are not enough on their own. 
- added the required TS compiler flag - https://mobx.js.org/migrating-from-4-or-5.html
- added `makeObservable` to the store constructor - https://mobx.js.org/observable-state.html#makeobservable

Fixes https://github.com/fullcalendar/fullcalendar/issues/6180